### PR TITLE
Correct the minimum Ansible version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.1
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,


### PR DESCRIPTION
The yumrepo is a new feature available only in Ansible 2.1 and as such, the minimal version should be correced to reflect that fact.
